### PR TITLE
Enable conversational planning with clarifications

### DIFF
--- a/Sap2000WinFormsSample/PlannerService.cs
+++ b/Sap2000WinFormsSample/PlannerService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -18,20 +19,32 @@ namespace Sap2000WinFormsSample
             _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         }
 
-        public async Task<Plan> MakePlanAsync(string userPrompt, string toolsCatalog)
+        public async Task<PlannerTurn> MakePlanAsync(List<ChatMessage> conversation, string toolsCatalog)
         {
-            var system = @"You are a task planner for a SAP2000 automation agent.
-Return STRICT JSON only with this schema (no comments, no markdown):
+            if (conversation == null || conversation.Count == 0)
+                throw new ApplicationException("Conversation must contain at least one user message.");
+
+            var system = @"You are a conversational planner for a SAP2000 automation agent.
+When the user prompt is incomplete, ask clarifying questions to gather the missing parameters before producing a plan.
+Always reply with STRICT JSON (no markdown, no commentary) that matches this schema:
 {
-  ""intent"": ""string"",
-  ""steps"": [
-    { ""action"": ""ActionName"", ""params"": { /* key: value */ }, ""confirm"": false }
-  ]
+  ""status"": ""plan_ready|need_clarification|error"",
+  ""message"": ""string"",
+  ""questions"": [""question1"", ""question2""]?,
+  ""plan"": {
+    ""intent"": ""string"",
+    ""steps"": [
+      { ""action"": ""ActionName"", ""params"": { /* key: value */ }, ""confirm"": false }
+    ]
+  }?
 }
 Rules:
+- If you need more information, set status=""need_clarification"", include a helpful message, and add one or more concrete questions. Omit the plan in that case.
+- When ready, set status=""plan_ready"", include a concise summary message, and provide a valid plan using only the allowed tools.
+- For errors, set status=""error"" and explain the issue in the message.
 - Use only actions from the provided tools catalog.
 - Be explicit with numeric values and units choice.
-- Prefer SI units unless user specifies otherwise.
+- Prefer SI units unless the user specifies otherwise.
 - Keep steps minimal and executable.";
 
             var payload = new
@@ -41,8 +54,7 @@ Rules:
                 {
                     new { role = "system", content = system },
                     new { role = "assistant", content = "Available tools:\n" + toolsCatalog },
-                    new { role = "user", content = userPrompt }
-                },
+                }.Concat(conversation.Select(m => new { role = m.Role, content = m.Content })),
                 temperature = 0.2
             };
 
@@ -66,10 +78,16 @@ Rules:
                 if (i >= 0 && j > i) content = content.Substring(i, j - i + 1);
             }
 
-            return JsonSerializer.Deserialize<Plan>(content, new JsonSerializerOptions
+            var turn = JsonSerializer.Deserialize<PlannerTurn>(content, new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             });
+
+            if (turn == null)
+                throw new ApplicationException("Planner returned invalid JSON.");
+
+            turn.rawContent = content;
+            return turn;
         }
 
         public static string BuildToolsCatalog(SkillRegistry reg)

--- a/Sap2000WinFormsSample/PlanningModels.cs
+++ b/Sap2000WinFormsSample/PlanningModels.cs
@@ -1,17 +1,41 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Sap2000WinFormsSample
 {
     public class Plan
     {
         public string intent { get; set; }                 // e.g., "design_reservoir"
-        public List<PlanStep> steps { get; set; } 
+        public List<PlanStep> steps { get; set; }
     }
 
     public class PlanStep
     {
         public string action { get; set; }                 // e.g., "InitializeBlankModel"
-        public Dictionary<string, object> @params { get; set; } 
+        public Dictionary<string, object> @params { get; set; }
         public bool confirm { get; set; }                  // ask user if true (for destructive ops)
+    }
+
+    public class PlannerTurn
+    {
+        public string status { get; set; }
+        public string message { get; set; }
+        public List<string> questions { get; set; }
+        public Plan plan { get; set; }
+        public string rawContent { get; set; }
+    }
+
+    public class ChatMessage
+    {
+        public string Role { get; }
+        public string Content { get; }
+
+        public ChatMessage(string role, string content)
+        {
+            Role = role;
+            Content = content;
+        }
+
+        public static ChatMessage User(string content) => new ChatMessage("user", content);
+        public static ChatMessage Assistant(string content) => new ChatMessage("assistant", content);
     }
 }

--- a/Sap2000WinFormsSample/PromptDialog.cs
+++ b/Sap2000WinFormsSample/PromptDialog.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Sap2000WinFormsSample
+{
+    public static class PromptDialog
+    {
+        public static string Show(string title, string prompt)
+        {
+            using (var form = new Form())
+            {
+                form.Text = title;
+                form.FormBorderStyle = FormBorderStyle.FixedDialog;
+                form.StartPosition = FormStartPosition.CenterParent;
+                form.MaximizeBox = false;
+                form.MinimizeBox = false;
+                form.ShowInTaskbar = false;
+                form.ClientSize = new Size(420, 170);
+
+                var lbl = new Label
+                {
+                    AutoSize = false,
+                    Text = prompt,
+                    Left = 12,
+                    Top = 12,
+                    Width = form.ClientSize.Width - 24,
+                    Height = 70
+                };
+
+                var txt = new TextBox
+                {
+                    Left = 12,
+                    Top = lbl.Bottom + 8,
+                    Width = form.ClientSize.Width - 24,
+                    Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top
+                };
+
+                var btnOk = new Button
+                {
+                    Text = "OK",
+                    DialogResult = DialogResult.OK
+                };
+
+                var btnCancel = new Button
+                {
+                    Text = "Cancel",
+                    DialogResult = DialogResult.Cancel
+                };
+
+                int buttonTop = txt.Bottom + 12;
+                btnOk.SetBounds(form.ClientSize.Width - 170, buttonTop, 75, 28);
+                btnCancel.SetBounds(form.ClientSize.Width - 85, buttonTop, 75, 28);
+
+                btnOk.Anchor = AnchorStyles.Right | AnchorStyles.Bottom;
+                btnCancel.Anchor = AnchorStyles.Right | AnchorStyles.Bottom;
+
+                form.Controls.AddRange(new Control[] { lbl, txt, btnOk, btnCancel });
+                txt.Focus();
+                form.AcceptButton = btnOk;
+                form.CancelButton = btnCancel;
+
+                var result = form.ShowDialog();
+                return result == DialogResult.OK ? txt.Text.Trim() : null;
+            }
+        }
+    }
+}

--- a/Sap2000WinFormsSample/Sap2000WinFormsSample.csproj
+++ b/Sap2000WinFormsSample/Sap2000WinFormsSample.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Orchestrator.cs" />
     <Compile Include="PlannerService.cs" />
     <Compile Include="PlanningModels.cs" />
+    <Compile Include="PromptDialog.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SapBuilder.cs" />

--- a/docs/prompt_agent_app.md
+++ b/docs/prompt_agent_app.md
@@ -1,0 +1,98 @@
+# Building a Prompt-Driven Task Automation App
+
+This guide outlines a practical approach to build an application that can interpret
+user prompts and orchestrate the right capabilities to complete the requested tasks.
+It combines natural language understanding, a catalog of actionable skills, and a
+planning/orchestration layer to deliver reliable results.
+
+## 1. Clarify Product Goals
+1. **Supported task categories** – Identify the domains you want the agent to handle
+   (e.g., data analysis, document drafting, design assistance, engineering
+   calculations). Start narrow so that you can curate reliable skills and extend over
+   time.
+2. **User interfaces** – Decide where users will interact with the agent (desktop,
+   web, chat widget, API) and whether synchronous or asynchronous execution is
+   required.
+3. **Success criteria** – Define measurable success signals (task completion rate,
+   user satisfaction, time saved) to guide iterative improvements.
+
+## 2. Gather Capabilities as "Skills"
+1. **Inventory existing automations** – Scriptable APIs, microservices, RPA bots,
+   and templates become the building blocks for the agent.
+2. **Wrap each capability** in a thin adapter that:
+   - Describes the skill in natural language (purpose, inputs, outputs).
+   - Validates incoming parameters.
+   - Handles execution and error normalization.
+3. **Version and test skills** so that orchestration can rely on their contracts.
+
+## 3. Choose an LLM & Prompting Strategy
+1. **Model selection** – Pick a language model that fits your latency, cost, and data
+   privacy requirements. Consider hybrid setups (local model for classification,
+   hosted model for reasoning) when necessary.
+2. **System prompts** – Craft role and safety instructions that keep the agent on
+   scope.
+3. **Few-shot exemplars** – Provide sample prompt-to-plan demonstrations to improve
+   reliability.
+4. **Memory strategy** – Combine short-term conversation state with long-term
+   knowledge bases (vector stores, SQL, CRM) if tasks depend on user context.
+
+## 4. Implement a Planner-Orchestrator
+1. **Parsing & classification** – Use the LLM (or fine-tuned classifiers) to map a
+   free-form prompt to candidate intents or skill sequences.
+2. **Planning loop** – Allow the agent to break multi-step tasks into an ordered
+   plan. Impose guardrails (max steps, allowed skills, confirmation prompts) to avoid
+   loops.
+3. **Execution management** – Sequentially call skills, track intermediate results,
+   and recover from failures with retries or fallbacks.
+4. **Human-in-the-loop controls** – Ask for confirmation when cost, safety, or
+   ambiguity thresholds are exceeded.
+
+## 5. Data Flow & Storage
+1. **State tracking** – Log every prompt, plan, action, and outcome for analytics.
+2. **Secure secret management** – Store API keys and credentials via a secrets vault.
+3. **Auditability** – Maintain structured records for compliance and debugging.
+
+## 6. UX Considerations
+1. **Transparent feedback** – Show users the plan, current step, and final summary to
+   build trust.
+2. **Intervention points** – Allow users to edit inputs, approve actions, or cancel
+   long-running steps.
+3. **Result packaging** – Provide downloadable artifacts (reports, code snippets)
+   formatted for the user’s workflow.
+
+## 7. Testing & Evaluation
+1. **Unit tests** – Cover individual skills and the planner’s decision logic with
+   deterministic test data.
+2. **Simulation harness** – Replay real prompts against mocked services to measure
+   success rates and safety incidents.
+3. **Canary rollouts** – Release updates to a small user cohort before global
+   deployment.
+
+## 8. Operations & Continuous Improvement
+1. **Telemetry dashboards** – Monitor latency, cost, and error trends.
+2. **Feedback loops** – Capture user ratings and incorporate supervised fine-tuning
+   or retrieval updates.
+3. **Skill lifecycle** – Add, deprecate, and improve skills based on observed demand
+   and performance.
+
+## 9. Security, Privacy, and Governance
+1. **Access control** – Ensure the agent only invokes skills the user is authorized
+   to use.
+2. **Data minimization** – Filter sensitive data before sending it to external LLMs
+   and redact logs.
+3. **Policy compliance** – Encode business rules and regulatory constraints inside
+   the planner or as validation layers.
+
+## 10. Roadmap for Incremental Delivery
+1. Ship a **minimum viable agent** with a handful of curated skills and tight
+   guardrails.
+2. Collect feedback, expand the skill catalog, and refine prompts based on observed
+   failures.
+3. Introduce autonomous planning for multi-step tasks once single-step reliability
+   is proven.
+
+---
+
+By combining a structured skill library with a planning orchestrator and robust
+operational practices, you can deliver an app that accepts natural language prompts
+and consistently executes the underlying tasks.


### PR DESCRIPTION
## Summary
- replace the single-shot JSON prompt with a conversational planner that can request missing details before producing a plan
- update the WinForms workflow to loop with the planner, prompt the user for clarifications, and execute the returned plan via the orchestrator
- add a reusable prompt dialog helper and include it in the project build

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd1d05edbc832796248adfdd56eaaa