### PR TITLE
Ensure blank SAP2000 model is created before setting units

### DIFF
--- a/Sap2000WinFormsSample/Skills.cs
+++ b/Sap2000WinFormsSample/Skills.cs
@@ -43,9 +43,16 @@ namespace Sap2000WinFormsSample
                 units = eUnits.kip_in_F;
             else
                 units = eUnits.kN_m_C;
-            int ret = model.SetPresentUnits(units);
+            int ret = model.InitializeNewModel(units);
+            if (ret != 0) throw new ApplicationException("InitializeNewModel failed.");
+
+            ret = model.File.NewBlank();
+            if (ret != 0) throw new ApplicationException("File.NewBlank failed.");
+
+            ret = model.SetPresentUnits(units);
             if (ret != 0) throw new ApplicationException("SetPresentUnits failed.");
-            return $"Units set to {units}.";
+
+            return $"Initialized new blank model with units set to {units}.";
         }
     }
 


### PR DESCRIPTION
## Summary
- update InitializeBlankModel skill to initialize and create a blank SAP2000 model before setting units
- improve the success message to reflect that a new blank model is ready

## Testing
- not run (SAP2000 dependency not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd22a36c44832783c78ab97aed071d