### PR TITLE
Improve clarification dialog for AI planning

### DIFF
--- a/Sap2000WinFormsSample/MainForm.cs
+++ b/Sap2000WinFormsSample/MainForm.cs
@@ -147,7 +147,8 @@ namespace Sap2000WinFormsSample
 
                     if (string.Equals(turn.status, "need_clarification", StringComparison.OrdinalIgnoreCase))
                     {
-                        Log(turn.message ?? "Planner needs more information.");
+                        var plannerMessage = turn.message ?? "The planner needs more information.";
+                        Log(plannerMessage);
                         if (turn.questions == null || turn.questions.Count == 0)
                         {
                             LogError("Planner requested clarification without questions. Stopping.");
@@ -156,7 +157,8 @@ namespace Sap2000WinFormsSample
 
                         foreach (var question in turn.questions)
                         {
-                            var answer = PromptDialog.Show("Clarification needed", question);
+                            Log($"Clarification requested: {question}");
+                            var answer = PromptDialog.ShowClarification("Clarification needed", plannerMessage, question);
                             if (answer == null)
                             {
                                 Log("User cancelled clarification. Aborting plan.");

--- a/Sap2000WinFormsSample/PromptDialog.cs
+++ b/Sap2000WinFormsSample/PromptDialog.cs
@@ -8,6 +8,16 @@ namespace Sap2000WinFormsSample
     {
         public static string Show(string title, string prompt)
         {
+            return ShowInternal(title, null, prompt, multiline: false);
+        }
+
+        public static string ShowClarification(string title, string agentMessage, string question)
+        {
+            return ShowInternal(title, agentMessage, question, multiline: true);
+        }
+
+        private static string ShowInternal(string title, string context, string prompt, bool multiline)
+        {
             using (var form = new Form())
             {
                 form.Text = title;
@@ -16,25 +26,48 @@ namespace Sap2000WinFormsSample
                 form.MaximizeBox = false;
                 form.MinimizeBox = false;
                 form.ShowInTaskbar = false;
-                form.ClientSize = new Size(420, 170);
+                form.ClientSize = new Size(460, multiline ? 260 : 180);
 
-                var lbl = new Label
+                int currentTop = 12;
+
+                if (!string.IsNullOrWhiteSpace(context))
+                {
+                    var contextLabel = new Label
+                    {
+                        AutoSize = false,
+                        Text = context,
+                        Left = 12,
+                        Top = currentTop,
+                        Width = form.ClientSize.Width - 24,
+                        Height = 70
+                    };
+                    contextLabel.Font = new Font(contextLabel.Font, FontStyle.Italic);
+                    form.Controls.Add(contextLabel);
+                    currentTop = contextLabel.Bottom + 10;
+                }
+
+                var promptLabel = new Label
                 {
                     AutoSize = false,
                     Text = prompt,
                     Left = 12,
-                    Top = 12,
+                    Top = currentTop,
                     Width = form.ClientSize.Width - 24,
-                    Height = 70
+                    Height = 50
                 };
+                form.Controls.Add(promptLabel);
 
                 var txt = new TextBox
                 {
                     Left = 12,
-                    Top = lbl.Bottom + 8,
+                    Top = promptLabel.Bottom + 8,
                     Width = form.ClientSize.Width - 24,
-                    Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top
+                    Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top,
+                    Multiline = multiline,
+                    Height = multiline ? 90 : 24,
+                    ScrollBars = multiline ? ScrollBars.Vertical : ScrollBars.None
                 };
+                form.Controls.Add(txt);
 
                 var btnOk = new Button
                 {
@@ -55,10 +88,13 @@ namespace Sap2000WinFormsSample
                 btnOk.Anchor = AnchorStyles.Right | AnchorStyles.Bottom;
                 btnCancel.Anchor = AnchorStyles.Right | AnchorStyles.Bottom;
 
-                form.Controls.AddRange(new Control[] { lbl, txt, btnOk, btnCancel });
-                txt.Focus();
+                form.Controls.Add(btnOk);
+                form.Controls.Add(btnCancel);
+
                 form.AcceptButton = btnOk;
                 form.CancelButton = btnCancel;
+
+                txt.Focus();
 
                 var result = form.ShowDialog();
                 return result == DialogResult.OK ? txt.Text.Trim() : null;


### PR DESCRIPTION
## Summary
- enhance the clarification prompt to include the planner message and multiline responses
- log clarification requests and feed responses back into the planning conversation

## Testing
- not run (requires Windows environment for .NET Framework WinForms project)


------
https://chatgpt.com/codex/tasks/task_e_68dd27cb6cb483279c7a235a046fd6eb