### PR TITLE
Ensure hydrostatic reservoir cases are marked to run

### DIFF
--- a/Sap2000WinFormsSample/Skills.cs
+++ b/Sap2000WinFormsSample/Skills.cs
@@ -383,8 +383,16 @@ namespace Sap2000WinFormsSample
 
         public string Execute(cSapModel model, Dictionary<string, object> args)
         {
+            // Make sure at least one reasonable case is active before running the solver.
+            model.Analyze.SetRunCaseFlag("HYDROSTATIC", true);
+            model.Analyze.SetRunCaseFlag("DEAD", true);
+
+            // Clear any stale results so the analysis can start cleanly.
+            model.Analyze.DeleteResults();
+
             int ret = model.Analyze.RunAnalysis();
-            if (ret != 0) throw new ApplicationException("RunAnalysis failed.");
+            if (ret != 0)
+                throw new ApplicationException($"RunAnalysis failed (code {ret}). Ensure that at least one load case is enabled.");
             return "Analysis completed.";
         }
     }


### PR DESCRIPTION
## Summary
- ensure the hydrostatic load case created for cylindrical reservoirs is marked to run and fall back to the default DEAD case when necessary
- always enable the DEAD load case as a safety net so blank models still have a runnable case
- update the RunAnalysis skill to enable common cases, clear stale results, and provide a clearer error message when analysis fails

## Testing
- `dotnet build Sap2000WinFormsSample/Sap2000WinFormsSample.csproj` *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd31e92d0c8327aaa7bd00f70eeb2e