### PR TITLE
Handle SAP2000 PropArea SetShell member-not-found dispatch errors

### DIFF
--- a/Sap2000WinFormsSample/SapBuilder.cs
+++ b/Sap2000WinFormsSample/SapBuilder.cs
@@ -617,7 +617,7 @@ namespace Sap2000WinFormsSample
                     {
                         continue;
                     }
-                    catch (TargetInvocationException tie) when (tie.InnerException is COMException comEx && IsDispatchParameterIssue(comEx))
+                    catch (TargetInvocationException tie) when (tie.InnerException is COMException comEx && IsDispatchRetryWorthy(comEx))
                     {
                         continue;
                     }
@@ -635,16 +635,18 @@ namespace Sap2000WinFormsSample
             throw new MissingMethodException($"Method '{methodName}' not found on type '{comType?.FullName}'.");
         }
 
-        private static bool IsDispatchParameterIssue(COMException comException)
+        private static bool IsDispatchRetryWorthy(COMException comException)
         {
             if (comException == null)
                 return false;
 
+            const int DISP_E_MEMBERNOTFOUND = unchecked((int)0x80020003);
             const int DISP_E_BADPARAMCOUNT = unchecked((int)0x8002000E);
             const int DISP_E_TYPEMISMATCH = unchecked((int)0x80020005);
 
             return comException.ErrorCode == DISP_E_BADPARAMCOUNT
-                || comException.ErrorCode == DISP_E_TYPEMISMATCH;
+                || comException.ErrorCode == DISP_E_TYPEMISMATCH
+                || comException.ErrorCode == DISP_E_MEMBERNOTFOUND;
         }
 
         private static IEnumerable<string> EnumerateCandidateMethodNames(Type comType, string baseName)


### PR DESCRIPTION
## Summary
- keep probing for alternate SetShell variants when the COM dispatch reports the member is missing
- allow the builder to fall back to suffixed methods so shell properties can be created on more SAP2000 versions

## Testing
- dotnet build Sap2000WinFormsSample.sln *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e25165c584832780e1c636fd75a69e